### PR TITLE
Update AP3 extension URI to v1 and enforce A2A activation

### DIFF
--- a/src/ap3/a2a/card.py
+++ b/src/ap3/a2a/card.py
@@ -24,9 +24,8 @@ from a2a.types import (
 )
 
 from ap3.a2a.wire import AP3_WIRE_VERSION
-from ap3.types import AP3ExtensionParameters, CommitmentMetadata
+from ap3.types import AP3_EXTENSION_URI, AP3ExtensionParameters, CommitmentMetadata
 
-AP3_EXTENSION_URI = "https://github.com/lfdt-ap3/ap3"
 _PARAM_AP3_VERSION = "ap3_version"
 _PARAM_WIRE_VERSION = "ap3_wire_version"
 _PARAM_PUBLIC_KEY = "public_key_hex"
@@ -154,8 +153,6 @@ def build_privacy_agent_card(
         required=True,
     )
     ext.params.CopyFrom(params)
-    if card.capabilities.extensions is None:
-        card.capabilities.extensions = []
     card.capabilities.extensions.append(ext)
     return card
 

--- a/src/ap3/a2a/client.py
+++ b/src/ap3/a2a/client.py
@@ -17,9 +17,14 @@ import contextlib
 import httpx
 
 from a2a.client import A2ACardResolver, ClientConfig, create_client
+from a2a.client.client import ClientCallContext
+from a2a.client.service_parameters import (
+    ServiceParametersFactory,
+    with_a2a_extensions,
+)
 from a2a.types import AgentCard, Message, Role, SendMessageRequest
 
-from ap3.a2a.card import PeerInfo, extract_peer_info
+from ap3.a2a.card import AP3_EXTENSION_URI, PeerInfo, extract_peer_info
 from ap3.a2a.wire import ProtocolEnvelope, envelope_from_parts, envelope_to_part
 
 logger = logging.getLogger(__name__)
@@ -129,9 +134,20 @@ class PeerClient:
             message.parts.append(envelope_to_part(envelope))
             request = SendMessageRequest(message=message)
 
+            # A2A spec: client SHOULD advertise activated extensions on every
+            # request via the `A2A-Extensions` header. The transport reads
+            # `ClientCallContext.service_parameters` and copies it into HTTP
+            # headers. Sending this on every AP3 envelope guarantees a peer
+            # whose extension is `required=True` will not reject us.
+            call_context = ClientCallContext(
+                service_parameters=ServiceParametersFactory.create(
+                    [with_a2a_extensions([AP3_EXTENSION_URI])]
+                )
+            )
+
             last_task = None
             reply: Optional[ProtocolEnvelope] = None
-            async for event in client.send_message(request):
+            async for event in client.send_message(request, context=call_context):
                 which = event.WhichOneof("payload")
                 if which == "task":
                     last_task = event.task

--- a/src/ap3/a2a/executor.py
+++ b/src/ap3/a2a/executor.py
@@ -21,6 +21,7 @@ from a2a.server.tasks import TaskUpdater
 from a2a.types import Task, TaskState, TaskStatus
 from a2a.utils.errors import UnsupportedOperationError
 
+from ap3.a2a.card import AP3_EXTENSION_URI
 from ap3.a2a.wire import ProtocolEnvelope, envelope_from_parts
 
 logger = logging.getLogger(__name__)
@@ -66,12 +67,28 @@ class PrivacyAgentExecutor(AgentExecutor):
         self._llm = llm_executor
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        # The A2A request handler populates these before dispatch. Guard
-        # explicitly rather than `assert`: asserts are stripped under `python -O`,
-        # which would let a None reach TaskUpdater or `context.message.parts`.
         if context.task_id is None or context.context_id is None or context.message is None:
             raise ValueError("A2A request context missing task_id, context_id, or message")
+
         updater = TaskUpdater(event_queue, context.task_id, context.context_id)
+
+        if AP3_EXTENSION_URI not in context.requested_extensions:
+            logger.warning(
+                "rejecting request: client did not advertise %s in A2A-Extensions header",
+                AP3_EXTENSION_URI,
+            )
+            if not context.current_task:
+                await event_queue.enqueue_event(
+                    Task(
+                        id=context.task_id,
+                        context_id=context.context_id,
+                        status=TaskStatus(state=TaskState.TASK_STATE_REJECTED),
+                    )
+                )
+            await updater.update_status(TaskState.TASK_STATE_REJECTED)
+            return
+
+        parts = list(context.message.parts)
         # a2a-sdk v1.x expects the task to exist in the stream before any
         # TaskStatusUpdateEvent. The request handler will persist/create the task,
         # but we also enqueue an initial Task event to satisfy strict stream
@@ -88,7 +105,7 @@ class PrivacyAgentExecutor(AgentExecutor):
         await updater.update_status(TaskState.TASK_STATE_WORKING)
 
         try:
-            envelope = envelope_from_parts(list(context.message.parts))
+            envelope = envelope_from_parts(parts)
         except ValueError as exc:
             # Multi-envelope, oversized envelope, or malformed envelope from
             # `envelope_from_parts`. Refuse cleanly with a structured failure
@@ -121,7 +138,13 @@ class PrivacyAgentExecutor(AgentExecutor):
             await updater.complete()
             return
         from ap3.a2a.wire import envelope_to_part  # avoid cycle at module load
-        await updater.add_artifact([envelope_to_part(reply)], last_chunk=True)
+        # Echo activated extension URI on the returned artifact so the peer
+        # can confirm we handled the envelope under the extension it activated.
+        await updater.add_artifact(
+            [envelope_to_part(reply)],
+            last_chunk=True,
+            extensions=[AP3_EXTENSION_URI],
+        )
         await updater.complete()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:

--- a/src/ap3/services/discovery.py
+++ b/src/ap3/services/discovery.py
@@ -5,17 +5,11 @@ from typing import Dict, Optional, Tuple
 
 import httpx
 
+from ap3.a2a.card import AP3_EXTENSION_URI
 from ap3.types import AP3ExtensionParameters
 from ap3.services.compatibility import CommitmentCompatibilityChecker
 
 logger = logging.getLogger(__name__)
-
-_AP3_EXTENSION_URIS = (
-    # Current canonical URI (used by `ap3.a2a.card.build_privacy_agent_card`)
-    "https://github.com/lfdt-ap3/ap3",
-    # Legacy URI seen in older docs/examples
-    "https://github.com/lfdt-ap3/ap3/tree/main",
-)
 
 class RemoteAgentDiscoveryService:
     """Service for discovering and checking compatibility with remote agents.
@@ -62,7 +56,7 @@ class RemoteAgentDiscoveryService:
             extensions = capabilities.get("extensions", [])
 
             for ext in extensions:
-                if ext.get("uri") in _AP3_EXTENSION_URIS:
+                if ext.get("uri") == AP3_EXTENSION_URI:
                     params = ext.get("params", {})
                     return AP3ExtensionParameters.model_validate(params)
 

--- a/src/ap3/types/__init__.py
+++ b/src/ap3/types/__init__.py
@@ -1,6 +1,7 @@
 """Agent Privacy-Preserving Protocol (AP3) types."""
 
 # Core types
+from ap3.types.core import AP3_EXTENSION_URI
 from ap3.types.core import OperationType
 from ap3.types.core import AP3Role
 from ap3.types.core import DataStructure
@@ -50,6 +51,7 @@ __all__ = [
     "PrivacyProtocolError",
     
     # Constants
+    "AP3_EXTENSION_URI",
     "PRIVACY_INTENT_DIRECTIVE_DATA_KEY",
     "PRIVACY_RESULT_DIRECTIVE_DATA_KEY",
 ]

--- a/src/ap3/types/core.py
+++ b/src/ap3/types/core.py
@@ -7,6 +7,8 @@ from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import AliasChoices
 
+AP3_EXTENSION_URI = "https://github.com/lfdt-ap3/ap3/v1"
+
 #### Operation types
 OperationType = Literal["PSI"]
 
@@ -146,7 +148,7 @@ class AP3ExtensionParameters(BaseModel):
         This formats the AP3 params in the structure needed for agent card extensions.
         """
         return {
-            "uri": "https://github.com/lfdt-ap3/ap3",
+            "uri": AP3_EXTENSION_URI,
             "description": "AP3 extension for privacy-preserving agent collaboration",
             "params": self.model_dump(mode='python'),
             "required": True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def mock_agent_card():
         "capabilities": {
             "extensions": [
                 {
-                    "uri": "https://github.com/lfdt-ap3/ap3/tree/main",
+                    "uri": "https://github.com/lfdt-ap3/ap3/v1",
                     "description": "AP3 extension",
                     "params": {
                         "roles": ["ap3_receiver"],

--- a/tests/unit/a2a/test_extension_activation.py
+++ b/tests/unit/a2a/test_extension_activation.py
@@ -1,0 +1,93 @@
+"""A2A extension-activation invariants for the AP3 executor.
+
+Two spec-mandated behaviors are covered here:
+
+- The extension URI on the AgentCard must be *versioned* (a plain
+  `github.com/lfdt-ap3/ap3` was refused by strict A2A consumers).
+- When the extension is declared `required=True`, the server MUST reject a
+  request that did not activate it via the `A2A-Extensions` HTTP header —
+  otherwise a client that never opted in could still smuggle envelopes
+  through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.types import Message, Role, SendMessageRequest, TaskState
+
+from ap3.a2a.card import AP3_EXTENSION_URI
+from ap3.a2a.executor import PrivacyAgentExecutor
+from ap3.a2a.wire import ProtocolEnvelope, envelope_to_part
+
+
+def test_ap3_extension_uri_is_versioned():
+    """A2A spec MUSTs the URI carry a version segment."""
+    assert AP3_EXTENSION_URI.rstrip("/").endswith("/v1"), AP3_EXTENSION_URI
+
+
+class _RecordingHandler:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def handle_envelope(self, envelope):
+        self.calls += 1
+        return None
+
+
+def _request_context(*, activated: bool) -> tuple[RequestContext, EventQueue]:
+    envelope = ProtocolEnvelope(
+        operation="psi", phase="msg1", session_id="sid-test", payload="p"
+    )
+    message = Message(role=Role.ROLE_USER, message_id="mid-1")
+    message.parts.append(envelope_to_part(envelope))
+    request = SendMessageRequest(message=message)
+
+    requested = {AP3_EXTENSION_URI} if activated else set()
+    call_context = ServerCallContext(requested_extensions=requested)
+    context = RequestContext(call_context=call_context, request=request)
+    return context, EventQueue()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_when_extension_not_activated():
+    handler = _RecordingHandler()
+    executor = PrivacyAgentExecutor(protocol_handler=handler)
+
+    context, queue = _request_context(activated=False)
+    await executor.execute(context, queue)
+
+    # Handler must never be reached — the header check fires first.
+    assert handler.calls == 0
+
+    # Drain the queue and check the terminal state is REJECTED.
+    seen_states: list[int] = []
+    while True:
+        try:
+            ev = await asyncio.wait_for(queue.dequeue_event(), timeout=0.1)
+        except (asyncio.TimeoutError, asyncio.QueueEmpty):
+            break
+        status = getattr(ev, "status", None)
+        if status is not None:
+            seen_states.append(status.state)
+        # Task events also carry a status
+        task = getattr(ev, "id", None) and ev
+        if task is not None and hasattr(task, "status"):
+            seen_states.append(task.status.state)
+    assert TaskState.TASK_STATE_REJECTED in seen_states
+
+
+@pytest.mark.asyncio
+async def test_executor_accepts_when_extension_activated():
+    handler = _RecordingHandler()
+    executor = PrivacyAgentExecutor(protocol_handler=handler)
+
+    context, queue = _request_context(activated=True)
+    await executor.execute(context, queue)
+
+    assert handler.calls == 1

--- a/tests/unit/services/test_discovery_service.py
+++ b/tests/unit/services/test_discovery_service.py
@@ -1,14 +1,15 @@
+from ap3.a2a.card import AP3_EXTENSION_URI
 from ap3.services.discovery import RemoteAgentDiscoveryService
 
 
-def test_extract_ap3_params_accepts_current_and_legacy_extension_uris():
+def test_extract_ap3_params_accepts_current_extension_uri():
     svc = RemoteAgentDiscoveryService()
 
-    base = {
+    card = {
         "capabilities": {
             "extensions": [
                 {
-                    "uri": "https://github.com/lfdt-ap3/ap3",
+                    "uri": AP3_EXTENSION_URI,
                     "params": {
                         "roles": ["ap3_initiator"],
                         "supported_operations": ["PSI"],
@@ -18,21 +19,31 @@ def test_extract_ap3_params_accepts_current_and_legacy_extension_uris():
             ]
         }
     }
-    assert svc.extract_ap3_params(base) is not None
+    assert svc.extract_ap3_params(card) is not None
 
-    legacy = {
-        "capabilities": {
-            "extensions": [
-                {
-                    "uri": "https://github.com/lfdt-ap3/ap3/tree/main",
-                    "params": {
-                        "roles": ["ap3_receiver"],
-                        "supported_operations": ["PSI"],
-                        "commitments": [],
-                    },
-                }
-            ]
+
+def test_extract_ap3_params_rejects_unversioned_legacy_uri():
+    # Pre-v1 unversioned URIs are no longer honored: A2A spec requires
+    # extension URIs to be versioned, and mixing versions silently would
+    # let a peer skip the version handshake.
+    svc = RemoteAgentDiscoveryService()
+
+    for legacy in (
+        "https://github.com/lfdt-ap3/ap3",
+        "https://github.com/lfdt-ap3/ap3/tree/main",
+    ):
+        card = {
+            "capabilities": {
+                "extensions": [
+                    {
+                        "uri": legacy,
+                        "params": {
+                            "roles": ["ap3_receiver"],
+                            "supported_operations": ["PSI"],
+                            "commitments": [],
+                        },
+                    }
+                ]
+            }
         }
-    }
-    assert svc.extract_ap3_params(legacy) is not None
-
+        assert svc.extract_ap3_params(card) is None

--- a/tests/unit/types/test_core.py
+++ b/tests/unit/types/test_core.py
@@ -67,11 +67,8 @@ class TestLiteralTypes:
     @pytest.mark.unit
     def test_operation_type(self):
         """Test OperationType literal type."""
-        # These should be valid values
-        op1: OperationType = "PSI"
-        op2: OperationType = "PIR"
-        assert op1 == "PSI"
-        assert op2 == "PIR"
+        op: OperationType = "PSI"
+        assert op == "PSI"
 
     @pytest.mark.unit
     def test_ap3_role(self):
@@ -202,7 +199,7 @@ class TestAP3ExtensionParameters:
         assert "uri" in extension
         assert "description" in extension
         assert "params" in extension
-        assert extension["uri"] == "https://github.com/lfdt-ap3/ap3"
+        assert extension["uri"] == "https://github.com/lfdt-ap3/ap3/v1"
         assert "params" in extension
         assert "roles" in extension["params"]
 


### PR DESCRIPTION
## Summary

- Wires up proper A2A extension support across the stack.

- The A2A spec requires extension URIs to be versioned: we were using a bare github.com/lfdt-ap3/ap3 URI which strict consumers reject. This PR fixes that and enforces the spec on both sides of the connection:

- URI is now …/ap3/v1

- Client advertises the extension via A2A-Extensions header on every request

- Executor rejects requests that don't include the header (so the handshake is actually enforced, not just advisory)

- Discovery drops the old URI fallback and matches /v1 only

## Test plan

- [x] Unit tests: `uv run pytest tests/unit/ -v`
- [ ] Integration tests (if applicable): `uv run pytest tests/integration/ -v`

## Notes

- Breaking: Peers on the old versioned URI will need to update.

