### PR TITLE
Generic operation type

### DIFF
--- a/src/ap3/a2a/_core.py
+++ b/src/ap3/a2a/_core.py
@@ -18,7 +18,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Optional
 
 from ap3.a2a.card import normalize_url
 from ap3.a2a.client import PeerClient, PeerInfo
@@ -29,7 +29,6 @@ from ap3.services.compatibility import CommitmentCompatibilityChecker
 from ap3.signing.canonical import canonical_json_bytes
 from ap3.types import (
     OperationProofs,
-    OperationType,
     PrivacyError,
     PrivacyIntentDirective,
     PrivacyProtocolError,
@@ -661,10 +660,7 @@ class _ProtocolCore:
         intent = PrivacyIntentDirective(
             ap3_session_id=session_id,
             intent_directive_id=str(uuid.uuid4()),
-            # The core is generic over operation type (a str); the directive
-            # pins Literal["PSI"]. Pydantic re-validates the value at
-            # construction, so this narrows the type without weakening the check.
-            operation_type=cast(OperationType, self._operation_type),
+            operation_type=self._operation_type,
             # Both URLs go through `normalize_url` so a peer that compares
             # against its own self_url with different trailing-slash/case/port
             # gets a match on legitimate traffic.

--- a/src/ap3/a2a/card.py
+++ b/src/ap3/a2a/card.py
@@ -154,8 +154,6 @@ def build_privacy_agent_card(
         required=True,
     )
     ext.params.CopyFrom(params)
-    if card.capabilities.extensions is None:
-        card.capabilities.extensions = []
     card.capabilities.extensions.append(ext)
     return card
 

--- a/src/ap3/services/compatibility.py
+++ b/src/ap3/services/compatibility.py
@@ -4,8 +4,10 @@ Design goals:
 - **Explainable**: return the reason for refusal, not just a boolean.
 - **Realistic**: select the best pair among commitments (even if today most
   deployments only publish one).
-- **Protocol-aware (optional)**: allow the caller to tighten rules for a
-  particular operation type (e.g. PSI).
+- **Operation-agnostic**: the SDK does not know about specific operations.
+  The `operation_type` parameter flows through as an opaque tag; operations
+  that need stricter pairing rules must plug in their own
+  `compatibility_scorer` (see `AP3Middleware`).
 """
 
 from __future__ import annotations
@@ -17,8 +19,6 @@ from ap3.types import (
     AP3ExtensionParameters,
     CommitmentMetadata,
     DataFreshness,
-    DataFormat,
-    DataStructure,
 )
 
 
@@ -66,19 +66,7 @@ class CommitmentCompatibilityChecker:
                 f" (note: industry differs: {commitment1.industry} vs {commitment2.industry})"
             )
 
-        if operation_type == "PSI":
-            # Current PSI examples assume structured records.
-            if commitment1.data_format != DataFormat.STRUCTURED:
-                return False, "PSI requires structured data format"
-
-            # Pragmatic PSI pairing: list-vs-list (customer list vs sanctions/blacklist).
-            allowed_structures = {DataStructure.CUSTOMER_LIST, DataStructure.BLACKLIST}
-            if (
-                commitment1.data_structure not in allowed_structures
-                or commitment2.data_structure not in allowed_structures
-            ):
-                allowed = ", ".join(sorted(s.value for s in allowed_structures))
-                return False, f"PSI requires commitments with data_structure in [{allowed}]"
+        del operation_type
 
         return True, f"Compatible: aligned format and freshness{industry_note}"
 

--- a/src/ap3/types/core.py
+++ b/src/ap3/types/core.py
@@ -8,7 +8,9 @@ from pydantic import Field
 from pydantic import AliasChoices
 
 #### Operation types
-OperationType = Literal["PSI"]
+# Operation IDs are opaque to the SDK. Concrete operations (e.g. "PSI") live
+# in separate packages such as ap3-functions and pick their own operation_id.
+OperationType = str
 
 #### Role types
 AP3Role = Literal["ap3_initiator", "ap3_receiver"]

--- a/src/ap3/types/directive.py
+++ b/src/ap3/types/directive.py
@@ -95,9 +95,8 @@ class PrivacyIntentDirective(BaseModel):
         if self.is_expired():
             return False, "Directive has expired"
         
-        # Valid operation type (pydantic already enforces the Literal)
-        if self.operation_type not in ["PSI"]:
-            return False, f"Invalid operation type: {self.operation_type}"
+        if not isinstance(self.operation_type, str) or not self.operation_type.strip():
+            return False, "operation_type must be a non-empty string"
 
         if not isinstance(self.nonce, str) or not self.nonce.strip():
             return False, "Missing nonce"

--- a/tests/integration/test_commitments.py
+++ b/tests/integration/test_commitments.py
@@ -203,12 +203,17 @@ class TestCommitmentCompatibilityWorkflow:
             commitments=[retail_metadata]
         )
 
-        # Agent 2: Finance (different industry)
+        # Agent 2: Finance with a stale (WEEKLY) commitment — generic
+        # freshness rule refuses this regardless of operation type.
         finance_schema = DataSchema(
             structure=DataStructure.FINANCIAL_RECORDS,
             format=DataFormat.STRUCTURED,
             fields=["account_id"],
-            metadata={"industry": "finance", "coverage_area": "global"}
+            metadata={
+                "industry": "finance",
+                "coverage_area": "global",
+                "update_frequency": "weekly",
+            },
         )
         finance_commitment = system.create_commitment(
             agent_id="finance_agent",
@@ -224,11 +229,9 @@ class TestCommitmentCompatibilityWorkflow:
             commitments=[finance_metadata]
         )
 
-        # Check compatibility
         score, explanation = CommitmentCompatibilityChecker.score_parameter_pair_compatibility(
             retail_params, finance_params, operation_type="PSI"
         )
 
-        # Should have roles + operations but fail on commitments
         assert score < 1.0
-        assert "PSI requires" in explanation
+        assert "fresh" in explanation.lower()

--- a/tests/unit/a2a/test_security_invariants.py
+++ b/tests/unit/a2a/test_security_invariants.py
@@ -339,10 +339,9 @@ async def test_intent_operation_type_mismatch_is_refused(monkeypatch):
     """An intent claiming a different operation_type than the receiver runs
     must never reach the operation layer.
 
-    Today pydantic's `Literal["PSI"]` rejects any other value at parse time
-    (INVALID_INTENT); the framework's explicit `INTENT_OPERATION_MISMATCH`
-    check is a defense-in-depth backstop for when a second operation type
-    lands and the Literal admits more than one value.
+    Mutating `operation_type` after signing breaks the signature
+    (BAD_SIGNATURE); the framework's explicit `INTENT_OPERATION_MISMATCH`
+    check is a defense-in-depth backstop.
     """
     agent, _, _ = _make_receiver()
     init_priv, init_pub = _make_initiator_keys()

--- a/tests/unit/types/test_directive.py
+++ b/tests/unit/types/test_directive.py
@@ -68,20 +68,22 @@ class TestPrivacyIntentDirective:
         assert "expired" in error.lower()
 
     @pytest.mark.unit
-    def test_validate_directive_invalid_operation(self, sample_session_id, future_time):
-        """Test validation fails with invalid operation type."""
-        # Pydantic validates on construction, so this should raise ValidationError
-        with pytest.raises(Exception) as exc_info:  # Catches pydantic ValidationError
-            PrivacyIntentDirective(
-                ap3_session_id=sample_session_id,
-                intent_directive_id=str(uuid.uuid4()),
-                operation_type="INVALID_OP",  # Invalid operation
-                participants=["http://agent1.example.com", "http://agent2.example.com"],
-                expiry=future_time.isoformat()
-            )
-        
-        # Verify it's a validation error about operation_type
-        assert "operation_type" in str(exc_info.value).lower() or "literal" in str(exc_info.value).lower()
+    def test_validate_directive_empty_operation_type(self, sample_session_id, future_time):
+        """operation_type is a free string but must be non-empty at validate time."""
+        directive = PrivacyIntentDirective(
+            ap3_session_id=sample_session_id,
+            intent_directive_id=str(uuid.uuid4()),
+            operation_type="   ",
+            participants=["http://agent1.example.com", "http://agent2.example.com"],
+            nonce="nonce_test",
+            payload_hash="0" * 64,
+            expiry=future_time.isoformat(),
+        )
+
+        is_valid, error = directive.validate_directive()
+
+        assert not is_valid
+        assert "operation_type" in error.lower()
 
     @pytest.mark.unit
     def test_is_expired_future_time(self, sample_privacy_intent_directive):


### PR DESCRIPTION
## Summary

- Make `OperationType` an opaque `str` (was `Literal["PSI"]`) so new operations (DP, PSI, etc.) ship as separate packages without touching `src/ap3/`.                                                                         
- Remove PSI-specific gate (`data_format == STRUCTURED` + `data_structure ∈ {CUSTOMER_LIST,BLACKLIST}`) from `CommitmentCompatibilityChecker`. Op-specific rules plug in via the existing `compatibility_scorer` hook.     
- `PrivacyIntentDirective.validate_directive()` now checks non-empty string instead of a Literal whitelist.Drop matching `cast()` in `_core.py`.                                                                         
- Fix latent bug in `build_privacy_agent_card`: removed dead `if extensions is None: = []` (proto repeated    
  field is None; assignment would raise.                                                                 

## Test plan

- [x] `uv run pytest tests/unit/ tests/integration/ -v`
- [x] `psi_simple`, `a2a-example`, `ap3_playground` (all 5 scenarios), `psi_adk_simple` — E2E green
- [x] mypy + ruff clean     

## Notes

- NA

